### PR TITLE
Changed dependency for xercesImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <dependency> <!-- Upper bounds conflict between Docix Core and JTH -->
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.11.0</version>
+        <version>2.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.doxia</groupId>


### PR DESCRIPTION
Changing the dependency for xercesImpl from 2.11.0 to 2.12.0.
The release of 2.11.0 is from Feb. 2013, and we are facing some problems with jenkins job dsl API I think it's related to this outdated version. 

https://issues.jenkins-ci.org/browse/JENKINS-27548