### PR TITLE
Refresh plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
-*.class
-.DS_Store
-.git
-test/*
-work/*
-target/*
-.settings/*
-*~
+target
+
+# mvn hpi:run
+work
+
+# IntelliJ IDEA project files
+*.iml
+*.iws
+*.ipr
+.idea
+
+# Eclipse project files
+.settings
+.classpath
 .project

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+### Version 1.3.0 (Feb 22, 2018)
+
+- [JENKINS-49586](https://issues.jenkins-ci.org/browse/JENKINS-49586) - Make the plugin compatible with Jenkins 2.102+
+- More info: [Plugins affected by fix for JEP-200](https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+fix+for+JEP-200)
+- [Commit](https://github.com/jenkinsci/jdepend-plugin/commit/0c8fbfa25f1dac94b1df242578b12da2cd4ac7ec)
+- Create JDepend temporary directory on controller (reverts change in 1.2.4)
+
+### Version 1.2.4 (Nov 03, 2014)
+
+- [Commit](https://github.com/jenkinsci/jdepend-plugin/commit/967b803b52c50d900408de10ad8535f4716af821) - Create JDepend temporary directory on agent instead of the controller
+
+### Version 1.2.3 (Feb 14, 2011)
+
+- Remove unused code.
+
+### Version 1.2.2 (Sep 17, 2009)
+
+- Fixed config file growth. ([JENKINS-4494](https://issues.jenkins-ci.org/browse/JENKINS-4494))
+
+### Version 1.2.1 (Aug 29, 2009)
+
+- Added relative path to workspace as a possible configuration. No compatibility for Ant-style FileSets though, there should only be one JDepend report.
+
+### Version 1.2
+
+- Use existing JDepend XML file. ([JENKINS-4083](https://issues.jenkins-ci.org/browse/JENKINS-4083))
+
+Version 1.0 was developed by Chris Lewis (lewisham).
+Development of version 1.0 of this plugin was made possible by the National Science Foundation and released under the BSD license from the University of California, Santa Cruz.
+If you like it, remember to keep voting for the public funding of scientific and educational facilities!

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,6 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, '2.104'])
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+])

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# JDepend
+
+The JDepend Plugin is a plugin to generate JDepend reports for builds.
+
+## Quickstart
+
+1. Download the JDepend plugin from the Update Center.
+2. Enable for a project by checking "Report JDepend" under the "Post-build actions" of your project.
+3. Run a build.
+4. View the build page once it has completed, and you should see a "JDepend" entry on the left sidebar.
+
+## Notes
+
+The JDepend plugin does not currently report the health of a project,
+as the sheer number of metrics available in a JDepend report makes it very difficult to find any sort of reasonable estimate of what makes a healthy project.
+This is one of the times when human intuition might be best!
+
+## Bug reporting
+
+Please direct all bugs to the [issue tracker](https://issues.jenkins.io/), making sure to mention "JDepend" somewhere in the heading or body.
+Bugs will continue to be looked at and fixed (features will not).
+
+## Feature requests
+
+Please direct all feature requests to the [issue tracker](https://issues.jenkins.io/), making sure to mention "JDepend" somewhere in the heading or body.
+Please note that active development on this plugin has ceased for the time being (the original itch has been scratched),
+so if you have new features, it will be quicker to try having a go yourself and make a commit to the Git repository.
+The code should be fairly good.

--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>4.49</version>
+    <relativePath />
   </parent>
   
   <artifactId>jdepend</artifactId>
   <packaging>hpi</packaging>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   
   <name>Jenkins JDepend Plugin</name>
   <description>A Jenkins plugin that uses JDepend to generate metrics.</description>
   <inceptionYear>2009</inceptionYear>
-  <url>https://wiki.jenkins.io/display/JENKINS/JDepend+Plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
-    <java.level>7</java.level>
-    <!-- TODO: Delete once FindBugs issues are fixed (4 issues) -->
-    <findbugs.failOnError>false</findbugs.failOnError>
+    <revision>1.3.1</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.319.1</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <!-- TODO fix violations -->
+    <spotbugs.threshold>High</spotbugs.threshold>
   </properties>
 
   <licenses>
@@ -72,6 +76,11 @@
           </exclusions>
       </dependency>
       <dependency>
+          <groupId>io.jenkins.plugins</groupId>
+          <artifactId>commons-httpclient3-api</artifactId>
+          <version>3.1-3</version>
+      </dependency>
+      <dependency>
           <groupId>jdepend</groupId>
           <artifactId>jdepend</artifactId>
           <version>2.9.1</version>
@@ -87,7 +96,7 @@
             <artifactId>commons-lang</artifactId>
           </exclusion>
           <exclusion>
-            <!-- Newer Jenkins cores use a patched version -->
+            <!-- Provided by commons-httpclient3-api plugin -->
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
           </exclusion>
@@ -120,11 +129,11 @@
     </pluginRepositories>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
+    </scm>
 </project>  
   
 

--- a/src/main/java/hudson/plugins/jdepend/JDependBuildAction.java
+++ b/src/main/java/hudson/plugins/jdepend/JDependBuildAction.java
@@ -13,7 +13,7 @@ import jenkins.model.RunAction2;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * A build action to generate JDepend HTML reports

--- a/src/main/java/hudson/plugins/jdepend/JDependRecorder.java
+++ b/src/main/java/hudson/plugins/jdepend/JDependRecorder.java
@@ -272,7 +272,7 @@ public class JDependRecorder extends Recorder
      * The class is marked as public so that it can be accessed from views.
      *
      * <p>
-     * See <tt>views/hudson/plugins/hello_world/JDependRecorder/*.jelly</tt>
+     * See {@code views/hudson/plugins/hello_world/JDependRecorder/*.jelly}
      * for the actual HTML fragment for the configuration screen.
      */
     @Extension
@@ -283,7 +283,7 @@ public class JDependRecorder extends Recorder
          * simply store it in a field and call save().
          *
          * <p>
-         * If you don't want fields to be persisted, use <tt>transient</tt>.
+         * If you don't want fields to be persisted, use {@code transient}.
          */
         public DescriptorImpl() {
             super(JDependRecorder.class);

--- a/src/main/java/hudson/plugins/jdepend/JDependReporter.java
+++ b/src/main/java/hudson/plugins/jdepend/JDependReporter.java
@@ -2,12 +2,13 @@ package hudson.plugins.jdepend;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.mojo.jdepend.JDependMojo;
-import org.w3c.tidy.Tidy;
 import org.apache.maven.doxia.module.xhtml.XhtmlSinkFactory;
 import org.apache.maven.doxia.sink.Sink;
 
@@ -44,24 +45,7 @@ public class JDependReporter extends JDependMojo
 	}
 	
 	/**
-	 * Tidies up the HTML, as the JDepend Sink outputs the HTML
-	 * all on one line, which is yucky.
-	 * 
-	 * @param htmlStream
-	 * @return tidied HTML as a String
-	 */
-	protected String tidyHtmlStream(ByteArrayOutputStream htmlStream) {
-        Tidy tidy = new Tidy();
-        ByteArrayOutputStream tidyStream = new ByteArrayOutputStream();
-        tidy.setXHTML(true);
-        tidy.setShowWarnings(false);
-        tidy.parse(new ByteArrayInputStream(htmlStream.toByteArray()), tidyStream);
-        
-        return tidyStream.toString();
-	}
-	
-	/**
-	 * Get the HTML report. This report is already run through HTML Tidy.
+	 * Get the HTML report.
 	 * @return HTML report
 	 * @throws MavenReportException when something bad happens
 	 */
@@ -70,7 +54,7 @@ public class JDependReporter extends JDependMojo
 	}
 	
 	/**
-	 * Get the HTML report. This report is already run through HTML Tidy.
+	 * Get the HTML report.
 	 * @param locale
 	 * @return
 	 * @throws MavenReportException
@@ -101,15 +85,13 @@ public class JDependReporter extends JDependMojo
             throw new MavenReportException("Failed to generate JDepend report:" + e.getMessage(), e);
         }
           
-        /**
-         * Running a tidy can create server problems as it can generate
-         * tens of thousands of lines. Disabled for now.
-         */
-        //return tidyHtmlStream(htmlStream);
-        
-        return htmlStream.toString();
-	}
-	
+        try {
+            return htmlStream.toString(Charset.defaultCharset().name());
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     protected ResourceBundle getBundle() {
         return ResourceBundle.getBundle("org.codehaus.mojo.jdepend.jdepend-report");
     }


### PR DESCRIPTION
This plugin currently consumes the deprecated Commons HttpClient 3.x API via Jenkins core. In https://github.com/jenkinsci/jenkins/pull/7312 we plan to remove this library from Jenkins core. To ensure this plugin continues to work, this PR prepares the plugin for https://github.com/jenkinsci/jenkins/pull/7312 by adding a dependency on the [Commons HttpClient 3.x API plugin](https://plugins.jenkins.io/commons-httpclient3-api/). While we were here, we refreshed the build toolchain and dependencies to recent versions.